### PR TITLE
updated makefile to use locally installed npm binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ compile:
 
 install:
 	mix do deps.get, compile
-	npm install -g api-spec-converter
+	npm install api-spec-converter
 
 serve:
 	mix phx.server
@@ -24,6 +24,7 @@ lint:
 test: format lint
 	mix test
 
+gen-spec: SHELL:=/bin/bash
 gen-spec:
 	mix covid19_orientation.open_api_3.gen_spec
-	api-spec-converter --from=openapi_3 --to=openapi_3 --syntax=yaml --check openapi3.json > openapi3.yaml
+	export PATH="$$(npm bin):$(PATH)" && api-spec-converter --from=openapi_3 --to=openapi_3 --syntax=yaml --check openapi3.json > openapi3.yaml


### PR DESCRIPTION
Pour éviter le messages d'erreurs lors du `make` et teinter l'environnement global, je propose ce fix pour installer et exécuter les bin npm en local