### PR TITLE
Ajout token à l'API /orientation

### DIFF
--- a/lib/covid19_orientation/data/store.ex
+++ b/lib/covid19_orientation/data/store.ex
@@ -11,7 +11,11 @@ defmodule Covid19Orientation.Data.Store do
   @tick_interval 1000
   @chunk_size 100
 
-  def write({date, uuid}, data = %{}) do
+  def write({date, uuid}, orientation = %{}) do
+    data = %{
+      data: %{orientation | date: date, uuid: uuid}
+    }
+
     GenServer.cast(__MODULE__, {:write, %{date: date, uuid: uuid, data: data}})
     data
   end

--- a/lib/covid19_orientation/data/token.ex
+++ b/lib/covid19_orientation/data/token.ex
@@ -1,0 +1,13 @@
+defmodule Covid19Orientation.Data.Token do
+    use Ecto.Schema
+    import Ecto.Changeset
+    alias Covid19Orientation.Data.Repo
+
+    @primary_key {:id, :binary_id, autogenerate: true}
+
+    schema "token" do
+        timestamps()
+    end
+
+    def create(), do: Repo.insert(%__MODULE__{})
+end

--- a/lib/covid19_orientation_web/controllers/token_controller.ex
+++ b/lib/covid19_orientation_web/controllers/token_controller.ex
@@ -1,0 +1,19 @@
+defmodule Covid19OrientationWeb.TokenController do
+  use Covid19OrientationWeb, :controller
+  alias Covid19Orientation.Data.Token
+  require Logger
+
+  def create(conn, _params) do
+    case Token.create() do
+        {:ok, token} ->
+            send_resp(conn, 201, token.id)
+        {:error, error} ->
+            Logger.error("Unable to create token")
+            Logger.error(error)
+
+            conn
+            |> put_status(500)
+            |> halt()
+    end
+  end
+end

--- a/lib/covid19_orientation_web/router.ex
+++ b/lib/covid19_orientation_web/router.ex
@@ -17,6 +17,7 @@ defmodule Covid19OrientationWeb.Router do
 
     get "/", BienvenueController, :index
     post "/orientation", OrientationController, :create
+    post "/token", TokenController, :create
   end
 
   scope "/" do

--- a/priv/repo/migrations/20200403152124_add_token.exs
+++ b/priv/repo/migrations/20200403152124_add_token.exs
@@ -1,0 +1,11 @@
+defmodule Covid19Orientation.Data.Repo.Migrations.AddToken do
+  use Ecto.Migration
+
+  def change do
+    create table(:token, primary_key: false) do
+      add :id, :uuid, primary_key: true
+
+      timestamps
+    end
+  end
+end

--- a/test/covid19_orientation/data/store_test.exs
+++ b/test/covid19_orientation/data/store_test.exs
@@ -4,8 +4,6 @@ defmodule Covid19Orientation.Data.StoreTest do
 
   alias Covid19OrientationWeb.Operations.{
     EvaluateOrientation,
-    SetDate,
-    SetUUID
   }
 
   alias Covid19OrientationWeb.Schemas.{
@@ -24,13 +22,9 @@ defmodule Covid19Orientation.Data.StoreTest do
       }
       |> EvaluateOrientation.call()
 
-    orientation =
-      orientation
-      |> SetDate.call()
-      |> SetUUID.call()
-
-    %{date: date, uuid: uuid} = orientation
-    data = Store.write({date, uuid}, %{data: orientation})
+    date = DateTime.utc_now()
+    uuid = "faketoken"
+    data = Store.write({date, uuid}, orientation)
 
     :timer.sleep(Store.tick_interval())
 

--- a/test/covid19_orientation_web/controllers/orientation_controller/create_test.exs
+++ b/test/covid19_orientation_web/controllers/orientation_controller/create_test.exs
@@ -35,9 +35,12 @@ defmodule Covid19OrientationWeb.OrientationController.CreateOrientation do
       }
     }
 
+    token = "faketoken"
+
     body =
       conn
       |> put_req_header("content-type", "application/json")
+      |> put_req_header("x-token", token)
       |> post("/orientation", payload)
       |> response(201)
       |> Jason.decode!()

--- a/test/covid19_orientation_web/controllers/token_controller/create_test.exs
+++ b/test/covid19_orientation_web/controllers/token_controller/create_test.exs
@@ -1,0 +1,13 @@
+defmodule Covid19OrientationWeb.TokenController.CreateTest do
+  use Covid19OrientationWeb.ConnCase, async: true
+
+  test "Creation d'un token", %{conn: conn} do
+
+    body =
+      conn
+      |> post("/token")
+      |> response(201)
+
+    assert String.length(body) == 36
+  end
+end


### PR DESCRIPTION
On peut maintenant obtenir un token qui est stocké en base en faisant un appel à `POST /token` une chaine de caractère correspondant au token est retournée.

Pour faire un appel à /orientation il faut maintenant passer ce token dans le header `X-TOKEN`