### PR TITLE
Suppression d'un lock dans le store

### DIFF
--- a/lib/covid19_questionnaire/data/store.ex
+++ b/lib/covid19_questionnaire/data/store.ex
@@ -44,14 +44,14 @@ defmodule Covid19Questionnaire.Data.Store do
 
   @impl true
   def handle_cast({:write, element}, to_write: to_write) do
-    Journal.create_many([element | to_write])
+    spawn fn -> Journal.create_many([element | to_write]) end
 
     {:noreply, [to_write: []]}
   end
 
   @impl true
   def handle_info(:tick, to_write: to_write) do
-    Journal.create_many(to_write)
+    spawn fn -> Journal.create_many(to_write) end
 
     tick()
     {:noreply, [to_write: []]}


### PR DESCRIPTION
Lors de l'écriture il y avait un lock sur la database qui est enlevé par le spawn